### PR TITLE
✨ Feature: support-jwt 모듈 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Claude Code ###
+tmpclaude*
+claude.md
+
+### Project Environments ###
+jwt-config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 ### Claude Code ###
 tmpclaude*
 claude.md
+.claude
 
 ### Project Environments ###
 jwt-config.yml

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ rootProject.name = 'geerok-backend'
 include(
         'core',
 
-        'boot:api-server',
+//        'boot:api-server',
 
         'support:support-jwt',
 //        'support:support-api',

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,11 @@ rootProject.name = 'geerok-backend'
 include(
         'core',
 
+        'boot:api-server',
+
+        'support:support-jwt',
+        'support:support-api',
+
         'account:account-rest',
         'account:account-app',
         'account:account-domain',

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,10 +6,10 @@ include(
         'boot:api-server',
 
         'support:support-jwt',
-        'support:support-api',
-
-        'account:account-rest',
-        'account:account-app',
-        'account:account-domain',
-        'account:account-infra',
+//        'support:support-api',
+//
+//        'account:account-rest',
+//        'account:account-app',
+//        'account:account-domain',
+//        'account:account-infra',
 )

--- a/support/support-jwt/build.gradle
+++ b/support/support-jwt/build.gradle
@@ -1,0 +1,20 @@
+dependencies {
+    implementation(project(":core"))
+
+    implementation 'org.springframework.security:spring-security-core'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Json web token
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+
+    // Test dependencies
+    testRuntimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    testRuntimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    testCompileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+
+    // TestFixtures dependencies
+    testFixturesImplementation(project(":core"))
+    testFixturesImplementation 'org.springframework.boot:spring-boot-starter-web'
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/JwtProvider.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/JwtProvider.java
@@ -1,0 +1,75 @@
+package io.geerok.support.jwt;
+
+import io.geerok.support.jwt.dto.AccessTokenPayload;
+import io.geerok.support.jwt.properties.JwtProperties;
+import io.geerok.support.jwt.tokens.AccessToken;
+import io.geerok.support.jwt.tokens.RefreshToken;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtProvider {
+    private final JwtProperties jwtProperties;
+    private Key accessTokenKey;
+    private Key refreshTokenKey;
+
+    @PostConstruct
+    public void init() {
+        byte[] accessTokenBytes = Base64.getDecoder().decode(jwtProperties.getAccessToken().getSecretKey());
+        accessTokenKey = Keys.hmacShaKeyFor(accessTokenBytes);
+
+        byte[] refreshTokenBytes = Base64.getDecoder().decode(jwtProperties.getRefreshToken().getSecretKey());
+        refreshTokenKey = Keys.hmacShaKeyFor(refreshTokenBytes);
+    }
+
+    public AccessToken generateAccessToken(AccessTokenPayload payload) {
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        LocalDateTime now = LocalDateTime.now(zoneId);
+        LocalDateTime expiresAt = now.plusSeconds(jwtProperties.getAccessToken().getExpiresIn());
+
+        Date expiresAtInDate = Date.from(expiresAt.atZone(zoneId).toInstant());
+
+        String token = Jwts.builder()
+                .claim("user_id", payload.userId())
+                .claim("nickname", payload.nickname())
+                .claim("authorities",payload.authorities())
+                .setExpiration(expiresAtInDate)
+                .signWith(accessTokenKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        return AccessToken.create(token, expiresAt);
+    }
+
+    public RefreshToken generateRefreshToken(Long userId) {
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        LocalDateTime now = LocalDateTime.now(zoneId);
+        LocalDateTime expiresAt = now.plusSeconds(jwtProperties.getRefreshToken().getExpiresIn());
+
+        Date expiresAtInDate = Date.from(expiresAt.atZone(zoneId).toInstant());
+        String jti = UUID.randomUUID().toString();
+
+        String token = Jwts.builder()
+                .claim("jti", jti)
+                .claim("user_id", userId)
+                .setExpiration(expiresAtInDate)
+                .signWith(refreshTokenKey, SignatureAlgorithm.HS256)
+                .compact();
+        log.debug("RefreshToken Generated for user {}: {}", userId, token);
+
+        return RefreshToken.create(jti, token, expiresAt);
+    }
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/JwtResolver.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/JwtResolver.java
@@ -1,0 +1,87 @@
+package io.geerok.support.jwt;
+
+import io.geerok.core.exception.utils.ExceptionCreator;
+import io.geerok.support.jwt.dto.AccessTokenPayload;
+import io.geerok.support.jwt.dto.RefreshTokenPayload;
+import io.geerok.support.jwt.properties.JwtProperties;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.DecodingException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.List;
+
+import static io.geerok.support.jwt.exception.JwtException.*;
+
+
+@Component
+@RequiredArgsConstructor
+public class JwtResolver {
+    private final JwtProperties jwtProperties;
+
+    private Key accessTokenKey;
+    private Key refreshTokenKey;
+
+    private final ObjectMapper objectMapper;
+
+    @PostConstruct
+    public void init() {
+        byte[] accessTokenBytes = Base64.getDecoder().decode(jwtProperties.getAccessToken().getSecretKey());
+        accessTokenKey = Keys.hmacShaKeyFor(accessTokenBytes);
+
+        byte[] refreshTokenBytes = Base64.getDecoder().decode(jwtProperties.getRefreshToken().getSecretKey());
+        refreshTokenKey = Keys.hmacShaKeyFor(refreshTokenBytes);
+    }
+
+    public AccessTokenPayload getPayloadFromAccessToken(String token) {
+        try {
+            if (token == null) throw ExceptionCreator.create(ACCESS_TOKEN_NOT_FOUND);
+
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(accessTokenKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            List<String> authorities = objectMapper.convertValue(
+                    claims.get("authorities", List.class),
+                    new TypeReference<>() {}
+            );
+
+            return new AccessTokenPayload(
+                    claims.get("user_id", Long.class),
+                    claims.get("nickname", String.class),
+                    authorities
+            );
+        } catch (SecurityException | UnsupportedJwtException | SignatureException | MalformedJwtException | DecodingException e) {
+            throw ExceptionCreator.create(ACCESS_TOKEN_INVALID, "AccessToken: " + token);
+        } catch (ExpiredJwtException e) {
+            throw ExceptionCreator.create(ACCESS_TOKEN_EXPIRED, "AccessToken: " + token);
+        }
+    }
+
+    public RefreshTokenPayload getPayloadFromRefreshToken(String token) {
+        try {
+            if (token == null) throw ExceptionCreator.create(REFRESH_TOKEN_NOT_FOUND);
+
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(refreshTokenKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return new RefreshTokenPayload(claims.get("user_id", Long.class));
+        } catch (SecurityException | UnsupportedJwtException | SignatureException | MalformedJwtException | DecodingException e) {
+            throw ExceptionCreator.create(REFRESH_TOKEN_INVALID, "RefreshToken: " + token);
+        } catch (ExpiredJwtException e) {
+            throw ExceptionCreator.create(REFRESH_TOKEN_EXPIRED, "RefreshToken: " + token);
+        }
+    }
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/dto/AccessTokenPayload.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/dto/AccessTokenPayload.java
@@ -1,0 +1,11 @@
+package io.geerok.support.jwt.dto;
+
+import java.util.List;
+
+public record AccessTokenPayload(
+        Long userId,
+        String nickname,
+        List<String> authorities
+) {
+
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/dto/RefreshTokenPayload.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/dto/RefreshTokenPayload.java
@@ -1,0 +1,6 @@
+package io.geerok.support.jwt.dto;
+
+public record RefreshTokenPayload(
+        Long userId
+) {
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/exception/JwtException.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/exception/JwtException.java
@@ -1,0 +1,27 @@
+package io.geerok.support.jwt.exception;
+
+import io.geerok.core.exception.UnauthorizedException;
+import io.geerok.core.exception.utils.ExceptionInterface;
+import lombok.Getter;
+
+@Getter
+public enum JwtException implements ExceptionInterface {
+    ACCESS_TOKEN_NOT_FOUND("JWT-901", "로그인이 필요한 서비스입니다. 로그인 후 이용해 주세요.", UnauthorizedException.class),
+    ACCESS_TOKEN_INVALID("JWT-902", "로그인 세션이 만료되었습니다. 다시 로그인해 주세요.", UnauthorizedException.class),
+    ACCESS_TOKEN_EXPIRED("JWT-903", "로그인 세션이 만료되었습니다. 다시 로그인해 주세요.", UnauthorizedException.class),
+
+    REFRESH_TOKEN_NOT_FOUND("JWT-904", "로그인이 필요한 서비스입니다. 로그인 후 이용해 주세요.", UnauthorizedException.class),
+    REFRESH_TOKEN_INVALID("JWT-905", "로그인 세션이 만료되었습니다. 다시 로그인해 주세요.", UnauthorizedException.class),
+    REFRESH_TOKEN_EXPIRED("JWT-906", "로그인 세션이 만료되었습니다. 다시 로그인해 주세요.", UnauthorizedException.class),
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final Class<?> aClass;
+
+    JwtException(String errorCode, String message, Class<?> aClass) {
+        this.errorCode = errorCode;
+        this.message = message;
+        this.aClass = aClass;
+    }
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/properties/JwtProperties.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/properties/JwtProperties.java
@@ -1,0 +1,20 @@
+package io.geerok.support.jwt.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "support.jwt")
+public class JwtProperties {
+    private JsonWebToken accessToken;
+    private JsonWebToken refreshToken;
+
+    @Data
+    public static class JsonWebToken {
+        public String tokenKey;
+        public String secretKey;
+        public Long expiresIn;
+    }
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/tokens/AccessToken.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/tokens/AccessToken.java
@@ -1,0 +1,12 @@
+package io.geerok.support.jwt.tokens;
+
+import java.time.LocalDateTime;
+
+public record AccessToken(
+        String token,
+        LocalDateTime expiresAt
+) implements AuthToken {
+    public static AccessToken create(final String token, final LocalDateTime expiresAt) {
+        return new AccessToken(token, expiresAt);
+    }
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/tokens/AuthToken.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/tokens/AuthToken.java
@@ -1,0 +1,8 @@
+package io.geerok.support.jwt.tokens;
+
+import java.time.LocalDateTime;
+
+public interface AuthToken {
+    String token();
+    LocalDateTime expiresAt();
+}

--- a/support/support-jwt/src/main/java/io/geerok/support/jwt/tokens/RefreshToken.java
+++ b/support/support-jwt/src/main/java/io/geerok/support/jwt/tokens/RefreshToken.java
@@ -1,0 +1,13 @@
+package io.geerok.support.jwt.tokens;
+
+import java.time.LocalDateTime;
+
+public record RefreshToken(
+        String jti,
+        String token,
+        LocalDateTime expiresAt
+) implements AuthToken {
+    public static RefreshToken create(final String jti, final String token, final LocalDateTime expiresAt) {
+        return new RefreshToken(jti, token, expiresAt);
+    }
+}

--- a/support/support-jwt/src/test/java/io/geerok/support/jwt/JwtProviderTest.java
+++ b/support/support-jwt/src/test/java/io/geerok/support/jwt/JwtProviderTest.java
@@ -1,0 +1,133 @@
+package io.geerok.support.jwt;
+
+import io.geerok.support.jwt.dto.AccessTokenPayload;
+import io.geerok.support.jwt.fixture.JwtPropertiesTestFixture;
+import io.geerok.support.jwt.fixture.AccessTokenPayloadTestFixture;
+import io.geerok.support.jwt.properties.JwtProperties;
+import io.geerok.support.jwt.tokens.AccessToken;
+import io.geerok.support.jwt.tokens.RefreshToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JwtProvider 테스트")
+class JwtProviderTest {
+
+    private JwtProvider jwtProvider;
+    private JwtProperties jwtProperties;
+
+    @BeforeEach
+    void setUp() {
+        jwtProperties = JwtPropertiesTestFixture.create();
+        jwtProvider = new JwtProvider(jwtProperties);
+        jwtProvider.init();
+    }
+
+    @Nested
+    @DisplayName("AccessToken 생성")
+    class GenerateAccessToken {
+
+        @Test
+        @DisplayName("유효한 payload로 AccessToken을 생성한다")
+        void shouldGenerateAccessTokenWithValidPayload() {
+            // given
+            AccessTokenPayload payload = AccessTokenPayloadTestFixture.create();
+
+            // when
+            AccessToken accessToken = jwtProvider.generateAccessToken(payload);
+
+            // then
+            assertThat(accessToken).isNotNull();
+            assertThat(accessToken.token()).isNotBlank();
+            assertThat(accessToken.expiresAt()).isAfter(LocalDateTime.now());
+        }
+
+        @Test
+        @DisplayName("다양한 권한을 가진 payload로 AccessToken을 생성한다")
+        void shouldGenerateAccessTokenWithMultipleAuthorities() {
+            // given
+            AccessTokenPayload payload = AccessTokenPayloadTestFixture.create(
+                    1L,
+                    "adminUser",
+                    List.of("ROLE_USER", "ROLE_ADMIN")
+            );
+
+            // when
+            AccessToken accessToken = jwtProvider.generateAccessToken(payload);
+
+            // then
+            assertThat(accessToken).isNotNull();
+            assertThat(accessToken.token()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("생성된 AccessToken의 만료 시간이 설정된 expiresIn과 일치한다")
+        void shouldHaveCorrectExpirationTime() {
+            // given
+            AccessTokenPayload payload = AccessTokenPayloadTestFixture.create();
+            LocalDateTime beforeGeneration = LocalDateTime.now();
+
+            // when
+            AccessToken accessToken = jwtProvider.generateAccessToken(payload);
+
+            // then
+            LocalDateTime expectedMinExpiry = beforeGeneration.plusSeconds(jwtProperties.getAccessToken().getExpiresIn());
+            assertThat(accessToken.expiresAt()).isAfterOrEqualTo(expectedMinExpiry.minusSeconds(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("RefreshToken 생성")
+    class GenerateRefreshToken {
+
+        @Test
+        @DisplayName("유효한 userId로 RefreshToken을 생성한다")
+        void shouldGenerateRefreshTokenWithValidUserId() {
+            // given
+            Long userId = 1L;
+
+            // when
+            RefreshToken refreshToken = jwtProvider.generateRefreshToken(userId);
+
+            // then
+            assertThat(refreshToken).isNotNull();
+            assertThat(refreshToken.token()).isNotBlank();
+            assertThat(refreshToken.expiresAt()).isAfter(LocalDateTime.now());
+        }
+
+        @Test
+        @DisplayName("동일한 userId로 생성된 RefreshToken은 매번 다른 값을 가진다")
+        void shouldGenerateDifferentTokensForSameUserId() {
+            // given
+            Long userId = 1L;
+
+            // when
+            RefreshToken token1 = jwtProvider.generateRefreshToken(userId);
+            RefreshToken token2 = jwtProvider.generateRefreshToken(userId);
+
+            // then
+            assertThat(token1.token()).isNotEqualTo(token2.token());
+        }
+
+        @Test
+        @DisplayName("생성된 RefreshToken의 만료 시간이 설정된 expiresIn과 일치한다")
+        void shouldHaveCorrectExpirationTime() {
+            // given
+            Long userId = 1L;
+            LocalDateTime beforeGeneration = LocalDateTime.now();
+
+            // when
+            RefreshToken refreshToken = jwtProvider.generateRefreshToken(userId);
+
+            // then
+            LocalDateTime expectedMinExpiry = beforeGeneration.plusSeconds(jwtProperties.getRefreshToken().getExpiresIn());
+            assertThat(refreshToken.expiresAt()).isAfterOrEqualTo(expectedMinExpiry.minusSeconds(1));
+        }
+    }
+}

--- a/support/support-jwt/src/test/java/io/geerok/support/jwt/JwtResolverTest.java
+++ b/support/support-jwt/src/test/java/io/geerok/support/jwt/JwtResolverTest.java
@@ -1,0 +1,169 @@
+package io.geerok.support.jwt;
+
+import io.geerok.core.exception.UnauthorizedException;
+import io.geerok.support.jwt.dto.AccessTokenPayload;
+import io.geerok.support.jwt.dto.RefreshTokenPayload;
+import io.geerok.support.jwt.fixture.JwtPropertiesTestFixture;
+import io.geerok.support.jwt.fixture.AccessTokenPayloadTestFixture;
+import io.geerok.support.jwt.properties.JwtProperties;
+import io.geerok.support.jwt.tokens.AccessToken;
+import io.geerok.support.jwt.tokens.RefreshToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("JwtResolver 테스트")
+class JwtResolverTest {
+
+    private JwtProvider jwtProvider;
+    private JwtResolver jwtResolver;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = JwtPropertiesTestFixture.create();
+
+        jwtProvider = new JwtProvider(jwtProperties);
+        jwtProvider.init();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        jwtResolver = new JwtResolver(jwtProperties, objectMapper);
+        jwtResolver.init();
+    }
+
+    @Nested
+    @DisplayName("AccessToken 파싱")
+    class GetPayloadFromAccessToken {
+
+        @Test
+        @DisplayName("유효한 AccessToken에서 payload를 추출한다")
+        void shouldExtractPayloadFromValidAccessToken() {
+            // given
+            AccessTokenPayload originalPayload = AccessTokenPayloadTestFixture.create();
+            AccessToken accessToken = jwtProvider.generateAccessToken(originalPayload);
+
+            // when
+            AccessTokenPayload extractedPayload = jwtResolver.getPayloadFromAccessToken(accessToken.token());
+
+            // then
+            assertThat(extractedPayload.userId()).isEqualTo(originalPayload.userId());
+            assertThat(extractedPayload.nickname()).isEqualTo(originalPayload.nickname());
+            assertThat(extractedPayload.authorities()).containsExactlyElementsOf(originalPayload.authorities());
+        }
+
+        @Test
+        @DisplayName("다중 권한을 가진 AccessToken에서 모든 권한을 추출한다")
+        void shouldExtractMultipleAuthoritiesFromAccessToken() {
+            // given
+            List<String> authorities = List.of("ROLE_USER", "ROLE_ADMIN", "ROLE_MANAGER");
+            AccessTokenPayload originalPayload = AccessTokenPayloadTestFixture.create(1L, "testUser", authorities);
+            AccessToken accessToken = jwtProvider.generateAccessToken(originalPayload);
+
+            // when
+            AccessTokenPayload extractedPayload = jwtResolver.getPayloadFromAccessToken(accessToken.token());
+
+            // then
+            assertThat(extractedPayload.authorities()).hasSize(3);
+            assertThat(extractedPayload.authorities()).containsExactlyElementsOf(authorities);
+        }
+
+        @Test
+        @DisplayName("null 토큰이 주어지면 예외를 발생시킨다")
+        void shouldThrowExceptionWhenTokenIsNull() {
+            // when & then
+            assertThatThrownBy(() -> jwtResolver.getPayloadFromAccessToken(null))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("잘못된 형식의 토큰이 주어지면 예외를 발생시킨다")
+        void shouldThrowExceptionWhenTokenIsInvalid() {
+            // given
+            String invalidToken = "invalid.token.format";
+
+            // when & then
+            assertThatThrownBy(() -> jwtResolver.getPayloadFromAccessToken(invalidToken))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("변조된 토큰이 주어지면 예외를 발생시킨다")
+        void shouldThrowExceptionWhenTokenIsTampered() {
+            // given
+            AccessTokenPayload payload = AccessTokenPayloadTestFixture.create();
+            AccessToken accessToken = jwtProvider.generateAccessToken(payload);
+            String tamperedToken = accessToken.token() + "tampered";
+
+            // when & then
+            assertThatThrownBy(() -> jwtResolver.getPayloadFromAccessToken(tamperedToken))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("RefreshToken 파싱")
+    class GetPayloadFromRefreshToken {
+
+        @Test
+        @DisplayName("유효한 RefreshToken에서 payload를 추출한다")
+        void shouldExtractPayloadFromValidRefreshToken() {
+            // given
+            Long userId = 1L;
+            RefreshToken refreshToken = jwtProvider.generateRefreshToken(userId);
+
+            // when
+            RefreshTokenPayload extractedPayload = jwtResolver.getPayloadFromRefreshToken(refreshToken.token());
+
+            // then
+            assertThat(extractedPayload.userId()).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("null 토큰이 주어지면 예외를 발생시킨다")
+        void shouldThrowExceptionWhenTokenIsNull() {
+            // when & then
+            assertThatThrownBy(() -> jwtResolver.getPayloadFromRefreshToken(null))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("잘못된 형식의 토큰이 주어지면 예외를 발생시킨다")
+        void shouldThrowExceptionWhenTokenIsInvalid() {
+            // given
+            String invalidToken = "invalid.token.format";
+
+            // when & then
+            assertThatThrownBy(() -> jwtResolver.getPayloadFromRefreshToken(invalidToken))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("AccessToken을 RefreshToken으로 파싱하면 예외를 발생시킨다")
+        void shouldThrowExceptionWhenAccessTokenUsedAsRefreshToken() {
+            // given
+            AccessTokenPayload payload = AccessTokenPayloadTestFixture.create();
+            AccessToken accessToken = jwtProvider.generateAccessToken(payload);
+
+            // when & then
+            assertThatThrownBy(() -> jwtResolver.getPayloadFromRefreshToken(accessToken.token()))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("RefreshToken을 AccessToken으로 파싱하면 예외를 발생시킨다")
+        void shouldThrowExceptionWhenRefreshTokenUsedAsAccessToken() {
+            // given
+            RefreshToken refreshToken = jwtProvider.generateRefreshToken(1L);
+
+            // when & then
+            assertThatThrownBy(() -> jwtResolver.getPayloadFromAccessToken(refreshToken.token()))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+    }
+}

--- a/support/support-jwt/src/testFixtures/java/io/geerok/support/jwt/fixture/AccessTokenPayloadTestFixture.java
+++ b/support/support-jwt/src/testFixtures/java/io/geerok/support/jwt/fixture/AccessTokenPayloadTestFixture.java
@@ -1,0 +1,19 @@
+package io.geerok.support.jwt.fixture;
+
+import io.geerok.support.jwt.dto.AccessTokenPayload;
+
+import java.util.List;
+
+public class AccessTokenPayloadTestFixture {
+    public static AccessTokenPayload create() {
+        return new AccessTokenPayload(
+                1L,
+                "testUser",
+                List.of("ROLE_USER")
+        );
+    }
+
+    public static AccessTokenPayload create(Long userId, String nickname, List<String> authorities) {
+        return new AccessTokenPayload(userId, nickname, authorities);
+    }
+}

--- a/support/support-jwt/src/testFixtures/java/io/geerok/support/jwt/fixture/JwtPropertiesTestFixture.java
+++ b/support/support-jwt/src/testFixtures/java/io/geerok/support/jwt/fixture/JwtPropertiesTestFixture.java
@@ -1,0 +1,28 @@
+package io.geerok.support.jwt.fixture;
+
+import io.geerok.support.jwt.properties.JwtProperties;
+
+public class JwtPropertiesTestFixture {
+    public static final String TEST_ACCESS_SECRET_KEY = "R2Vlcm9rQWNjZXNzVG9rZW5TZWN1cmVLZXlGb3JKV1RBdXRoZW50aWNhdGlvbldpdGhIUzUxMkFsZ29yaXRobUFuZFN0cm9uZ1NlY3VyaXR5MTIz";
+    public static final String TEST_REFRESH_SECRET_KEY = "R2Vlcm9rUmVmcmVzaFRva2VuU2VjdXJlS2V5Rm9yTG9uZ1Rlcm1BdXRoZW50aWNhdGlvblNlc3Npb25NYW5hZ2VtZW50V2l0aEhTNTEyNDU2";
+    public static final Long TEST_EXPIRES_IN = 1800L;
+
+    public static JwtProperties create() {
+        JwtProperties properties = new JwtProperties();
+
+        JwtProperties.JsonWebToken accessToken = new JwtProperties.JsonWebToken();
+        accessToken.setTokenKey("access-token");
+        accessToken.setSecretKey(TEST_ACCESS_SECRET_KEY);
+        accessToken.setExpiresIn(TEST_EXPIRES_IN);
+
+        JwtProperties.JsonWebToken refreshToken = new JwtProperties.JsonWebToken();
+        refreshToken.setTokenKey("refresh-token");
+        refreshToken.setSecretKey(TEST_REFRESH_SECRET_KEY);
+        refreshToken.setExpiresIn(TEST_EXPIRES_IN);
+
+        properties.setAccessToken(accessToken);
+        properties.setRefreshToken(refreshToken);
+
+        return properties;
+    }
+}


### PR DESCRIPTION
## 📝 변경 사항                                         
  - JWT 토큰 생성 및 검증을 위한 support-jwt 모듈 구현
  - JwtProvider: AccessToken, RefreshToken 생성 기능
  - JwtResolver: 토큰에서 payload 추출 및 검증 기능
  - JwtProperties: JWT 설정을 위한 ConfigurationProperties 클래스
  - JwtException: JWT 관련 예외 정의 (토큰 만료, 유효하지 않은 토큰 등)
  - 테스트 코드 작성 (JwtProviderTest, JwtResolverTest)
  - testFixtures를 활용한 테스트 픽스처 구현

## 📖 사용 매뉴얼

### JwtProvider
JWT 토큰을 생성하는 컴포넌트입니다.

**주요 메서드:**
- `generateAccessToken(AccessTokenPayload payload)`: 사용자 정보(userId, nickname, authorities)를 포함한 AccessToken 생성
- `generateRefreshToken(Long userId)`: userId를 포함한 RefreshToken 생성

**사용 예시:**
```java
  @RequiredArgsConstructor
  public class AuthService {
      private final JwtProvider jwtProvider;

      public AuthTokens login(User user) {
          AccessTokenPayload payload = new AccessTokenPayload(
              user.getId(),
              user.getNickname(),
              List.of("ROLE_USER")
          );

          AccessToken accessToken = jwtProvider.generateAccessToken(payload);
          RefreshToken refreshToken = jwtProvider.generateRefreshToken(user.getId());

          return new AuthTokens(accessToken, refreshToken);
      }
  }
```
### JwtResolver

JWT 토큰을 검증하고 payload를 추출하는 컴포넌트입니다.

**주요 메서드:**
- getPayloadFromAccessToken(String token): AccessToken에서 AccessTokenPayload 추출
- getPayloadFromRefreshToken(String token): RefreshToken에서 RefreshTokenPayload 추출

**사용 예시:**
```java
  @RequiredArgsConstructor
  public class AuthFilter {
      private final JwtResolver jwtResolver;

      public Authentication authenticate(String token) {
          AccessTokenPayload payload = jwtResolver.getPayloadFromAccessToken(token);
          return new UserAuthentication(payload.userId(), payload.authorities());
      }
  }
```

### 환경 설정 파일 (jwt-config.yml)

위치: support/support-jwt/src/main/resources/jwt-config.yml

**형식:**
```yaml
  ---
  spring.config.activate.on-profile: local

  support:
    jwt:
      accessToken:
        token-key: "access-token"           # 토큰 헤더/쿠키 키 이름
        secret-key: <Base64 인코딩된 시크릿 키>  # HS256 서명용 (최소 32바이트)
        expires-in: 1800                    # 만료 시간 (초 단위, 1800 = 30분)
      refreshToken:
        token-key: "refresh-token"
        secret-key: <Base64 인코딩된 시크릿 키>
        expires-in: 2592000                 # 만료 시간 (초 단위, 2592000 = 30일)
  ---
```

**Boot 모듈에서 import:**
```yaml
  # boot/api-server/src/main/resources/application.yml
  spring:
    config:
      import: classpath:jwt-config.yml
```

## 🔗 관련 이슈

  - Closes #5

## ✅ 체크리스트

  - 코드 작성 완료
  - 단위 테스트 작성
  - Swagger 문서화
  - 로컬 환경 테스트

##🚨 Breaking Changes
  - 없음
